### PR TITLE
added action file for firewalld

### DIFF
--- a/action.d/endlessh-firewalld.conf
+++ b/action.d/endlessh-firewalld.conf
@@ -1,0 +1,13 @@
+[INCLUDES]
+
+before = firewallcmd-common.conf
+
+[Definition]
+actionban   = firewall-cmd --zone=public --add-rich-rule='rule family="<family>" source address="<ip>" forward-port port="22" protocol="tcp" to-port="2222"'
+actionunban = firewall-cmd --zone=public --remove-rich-rule='rule family="<family>" source address="<ip>" forward-port port="22" protocol="tcp" to-port="2222"'
+actioncheck =
+actionstart =
+actionstop =
+
+[Init]
+blocktype = blackhole


### PR DESCRIPTION
Created a version of the action file that creates rules in firewalld.

I tested it with both ipv4 and ipv6 addresses and the <family> tag should mark things correctly. I used openSUSE Tumbleweed with kernel 5.18.9-1 and it appears to be doing the trick. The remove rules also works, I see the rules go away when fail2ban is stopped as a service.

The iptables version of the file didn't work for me because my openSUSE version didn't have the kernel modules for iptables and its NAT. This it forced me to make a firewalld version (necessity being a mother to such things). Maybe this will be helpful for other people who use firewalld.